### PR TITLE
Deploying Sanity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,7 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# Sanity
+/.sanity
+/dist

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "styled-components": "^5.2",
     "swiper": "^9.0.5",
     "typescript": "4.9.5",
-    "video-react": "^0.16.0"
+    "video-react": "^0.16.0",
+    "vite-tsconfig-paths": "^4.0.5"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^5.52.0",

--- a/pages/mg-admin/[[...index]].tsx
+++ b/pages/mg-admin/[[...index]].tsx
@@ -1,5 +1,5 @@
 import { NextStudio } from 'next-sanity/studio';
-import { config } from 'sanity.config';
+import config from 'sanity.config';
 
 export default function StudioPage() {
   return <NextStudio config={config} />;

--- a/sanity.cli.ts
+++ b/sanity.cli.ts
@@ -1,0 +1,20 @@
+import { loadEnvConfig } from '@next/env';
+import { defineCliConfig } from 'sanity/cli';
+import tsconfigPaths from 'vite-tsconfig-paths';
+
+const dev = process.env.NODE_ENV !== 'production';
+loadEnvConfig(__dirname, dev, { info: () => null, error: console.error });
+
+// @TODO report top-level await bug
+// Using a dynamic import here as `loadEnvConfig` needs to run before this file is loaded
+// const { projectId, dataset } = await import('lib/sanity.api')
+const projectId = process.env.NEXT_PUBLIC_SANITY_PROJECT_ID;
+const dataset = process.env.NEXT_PUBLIC_SANITY_DATASET;
+
+export default defineCliConfig({
+  api: { projectId, dataset },
+  vite: (viteConfig) => ({
+    ...viteConfig,
+    plugins: [tsconfigPaths(), ...viteConfig.plugins],
+  }),
+});

--- a/sanity.config.ts
+++ b/sanity.config.ts
@@ -10,7 +10,7 @@ import {
   cloudinarySchemaPlugin,
 } from 'sanity-plugin-cloudinary';
 
-export const config = defineConfig({
+const config = defineConfig({
   basePath: process.env.NEXT_PUBLIC_SANITY_BASE_PATH,
   dataset: process.env.NEXT_PUBLIC_SANITY_DATASET as string,
   form: {
@@ -35,3 +35,5 @@ export const config = defineConfig({
   },
   title: process.env.NEXT_PUBLIC_SANITY_TITLE,
 });
+
+export default config;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "ES2017",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -5822,6 +5822,11 @@ ts-md5@^1.3.1:
   resolved "https://registry.yarnpkg.com/ts-md5/-/ts-md5-1.3.1.tgz#f5b860c0d5241dd9bb4e909dd73991166403f511"
   integrity sha512-DiwiXfwvcTeZ5wCE0z+2A9EseZsztaiZtGrtSaY5JOD7ekPnR/GoIVD5gXZAlK9Na9Kvpo9Waz5rW64WKAWApg==
 
+tsconfck@^2.0.1:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/tsconfck/-/tsconfck-2.0.3.tgz#47b79fc6be3c5ec6ec9b3862d1c959e85038b117"
+  integrity sha512-o3DsPZO1+C98KqHMdAbWs30zpxD30kj8r9OLA4ML1yghx4khNDzaaShNalfluh8ZPPhzKe3qyVCP1HiZszSAsw==
+
 tsconfig-paths@^3.14.1:
   version "3.14.1"
   resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-3.14.1.tgz#ba0734599e8ea36c862798e920bcf163277b137a"
@@ -6044,6 +6049,15 @@ video-react@^0.16.0:
     lodash.throttle "^4.1.1"
     prop-types "^15.7.2"
     redux "^4.0.1"
+
+vite-tsconfig-paths@^4.0.5:
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/vite-tsconfig-paths/-/vite-tsconfig-paths-4.0.5.tgz#c7c54e2cf7ccc5e600db565cecd7b368a1fa8889"
+  integrity sha512-/L/eHwySFYjwxoYt1WRJniuK/jPv+WGwgRGBYx3leciR5wBeqntQpUE6Js6+TJemChc+ter7fDBKieyEWDx4yQ==
+  dependencies:
+    debug "^4.1.1"
+    globrex "^0.1.2"
+    tsconfck "^2.0.1"
 
 vite@^4.0.1:
   version "4.1.1"


### PR DESCRIPTION
## Description
Even though Sanity now lives in the same website, it still needs to be deployed, and for that following changes are required:
* create `sanity.cli.ts`
* install `vite` dependencies to allow sanity build process to resolve _aliases_ in `tsconfig.json`
* `sanity.config` is now `exported default`
* update .gitignore adding `/dist` and `/.sanity` folders
* update `target` property in `tsconfig`