### PR TITLE
Alejandro & Taylor individual pages

### DIFF
--- a/lib/queries.ts
+++ b/lib/queries.ts
@@ -32,6 +32,6 @@ export const dropBySlugQuery = groq`
   *[_type == "drop" && slug.current == $slug][0]
 `;
 
-export const collectionsQuery = groq`
-  *[_type == "alejandro-and-taylor-collections"]
+export const alejandroAndTaylorCollectionsQuery = groq`
+  *[_type == "alejandro-and-taylor-collections" && artist == $artist] | order(collectionNumber asc)
 `;

--- a/lib/sanity.client.ts
+++ b/lib/sanity.client.ts
@@ -4,7 +4,11 @@ import { config } from 'sanity.config';
 const token = process.env.NEXT_PUBLIC_SANITY_CREATE_TOKEN;
 
 export const sanityClient = createClient({
+  // use same config as in studio
   ...config,
+  // use a today's UTC date unless there is a reason not to
+  // docs: https://www.sanity.io/help/js-client-api-version
+  apiVersion: '2023-03-11',
   token,
   useCdn: false,
 });

--- a/lib/schemas/alejandro-and-taylor-collections.ts
+++ b/lib/schemas/alejandro-and-taylor-collections.ts
@@ -3,6 +3,20 @@ import { defineField, defineType } from 'sanity';
 export const alejandroAndTaylorCollections = defineType({
   fields: [
     defineField({
+      name: 'artist',
+      options: {
+        direction: 'horizontal',
+        layout: 'radio',
+        list: [
+          { value: 'alejandro', title: 'Alejandro' },
+          { value: 'taylor', title: 'Taylor' },
+        ],
+      },
+      title: 'Choose the artist',
+      type: 'string',
+      validation: (rule) => rule.required(),
+    }),
+    defineField({
       name: 'collectionNumber',
       title: 'Collection Number',
       type: 'number',
@@ -24,6 +38,12 @@ export const alejandroAndTaylorCollections = defineType({
     }),
   ],
   name: 'alejandro-and-taylor-collections',
+  preview: {
+    select: {
+      title: 'collectionName',
+      subtitle: 'artist',
+    },
+  },
   title: 'Alejandro & Taylor Collections',
   type: 'document',
 });

--- a/modules/alejandro-and-taylor/components/TheArtists.tsx
+++ b/modules/alejandro-and-taylor/components/TheArtists.tsx
@@ -1,5 +1,6 @@
 import Image from 'next/image';
 import Link from 'next/link';
+import { ALEJANDRO_PAGE, TAYLOR_PAGE } from 'utils/routes';
 
 const ALEJANDRO_COVER =
   'https://res.cloudinary.com/do1gnj1vn/image/upload/v1678398974/Alejandro%20and%20Taylor/Alejandro/artist2_photos_v2_x4_zqmpvm.jpg';
@@ -14,7 +15,7 @@ export default function TheArtists() {
         <h2 className="my-6 text-2xl">The Artists</h2>
       </div>
       <div className="grid grid-cols-2 gap-3 mx-auto max-w-screen-2xl">
-        <Link className="relative" href="/alejandro-and-taylor/alejandro">
+        <Link className="relative" href={ALEJANDRO_PAGE}>
           <div className="relative z-0 overflow-hidden h-[600px]">
             <Image
               alt="imagen"
@@ -28,7 +29,7 @@ export default function TheArtists() {
             Alejandro
           </h2>
         </Link>
-        <Link className="relative" href="/alejandro-and-taylor/alejandro">
+        <Link className="relative" href={TAYLOR_PAGE}>
           <div className="relative z-0 overflow-hidden h-[600px]">
             <Image
               alt="imagen"

--- a/pages/alejandro-and-taylor/taylor.tsx
+++ b/pages/alejandro-and-taylor/taylor.tsx
@@ -1,5 +1,4 @@
 import Image from 'next/image';
-import AlejandroHero from 'modules/alejandro-and-taylor/components/AlejandroHero';
 import { GetStaticProps, GetStaticPropsResult } from 'next';
 import { AlejandroAndTaylorCollection } from 'types/alejandroAndTaylorCollections';
 import { sanityClient } from 'lib/sanity.client';
@@ -8,9 +7,9 @@ import { useCallback, useState } from 'react';
 import { OpenSeaButtonLink } from 'components/Link/OpenSeaButtonLink';
 import { MARKETPLACE_URLS } from 'utils/constants';
 
-const ARTIST_NAME = 'alejandro';
+const ARTIST_NAME = 'taylor';
 
-export default function AlejandroPage({
+export default function TaylorPage({
   collections,
 }: {
   collections: AlejandroAndTaylorCollection[];
@@ -29,7 +28,6 @@ export default function AlejandroPage({
 
   return (
     <div className="w-full pb-24">
-      <AlejandroHero />
       <div className="my-20 border-b border-gray-300">
         <div className="flex items-center justify-start gap-12 px-2 py-3 mx-auto max-w-screen-2xl">
           {collections.map(({ collectionNumber }, index) => (

--- a/utils/routes.ts
+++ b/utils/routes.ts
@@ -33,6 +33,11 @@ export const ROUTES = [
 
 export const CURATED_DROP_DETAILS = '/curated/drop';
 
+// DREAMER PAGES
 export const DREAMERS_8000_DREAMERS = '/dreamers/8000-dreamers';
 export const DREAMERS_DREAMING_OF_A_BETTER_WORLD =
   '/dreamers/dreaming-a-better-world';
+
+// ALEJANDRO & TAYLOR PAGES
+export const ALEJANDRO_PAGE = '/alejandro-and-taylor/alejandro';
+export const TAYLOR_PAGE = '/alejandro-and-taylor/taylor';


### PR DESCRIPTION
# Description
Solves issue #62 , plus add `apiVersion` to sanity client

### Changes

- Update schema for A & T adding a radio to choose betwen the two
- New fixed page taylor.tsx
- Update page alejandro.tsx to pass the artiist name into the query
- Single query to retrieve their content by $artist, ordered by collection number
- Link to their own pages from their covers
- add `apiVersion` into Sanity as suggested in logs: https://www.sanity.io/help/js-client-api-version