### PR TITLE
Add artist names in DropCoverOverlay

### DIFF
--- a/modules/curated/components/CuratedGallery.tsx
+++ b/modules/curated/components/CuratedGallery.tsx
@@ -48,7 +48,11 @@ export const CuratedGallery = ({ drops }: CuratedGalleryProps) => {
             >
               <DropCover drop={drop} />
               {hoveredDrop === drop._id && (
-                <DropCoverOverlay name={drop.name} status={drop.status} />
+                <DropCoverOverlay
+                  artists={drop.artists}
+                  name={drop.name}
+                  status={drop.status}
+                />
               )}
             </div>
           ))}

--- a/modules/curated/components/DropCoverOverlay.tsx
+++ b/modules/curated/components/DropCoverOverlay.tsx
@@ -5,15 +5,23 @@ import { RightArrow } from 'components/Svgs/RightArrow';
 import { MintStatusText } from 'modules/curated/components/DropsFilter';
 
 type DropCoverOverlayProps = {
+  artists: Drop['artists'];
   name: Drop['name'];
   status: Drop['status'];
 };
 
-export const DropCoverOverlay = ({ name, status }: DropCoverOverlayProps) => (
+export const DropCoverOverlay = ({
+  artists,
+  name,
+  status,
+}: DropCoverOverlayProps) => (
   <div className={styles.dropOverlay}>
     <p>{MintStatusText[status]}</p>
-    <div className="flex items-center justify-between">
-      <h3>{name}</h3>
+    <div className="flex items-end justify-between">
+      <div>
+        <h3 className="text-lg">{name}</h3>
+        <p className="text-sm">{artists[0].name}</p>
+      </div>
       <RightArrow className="w-6 h-6" />
     </div>
   </div>


### PR DESCRIPTION
# Description
Add artist names under the drop name in when the user hovers a drop in the Curated page (`/curated`)

### Changes
* Pass drop.artists to `<DropCoverOverlay>`
* Loop through artist names (there is always one but there could be 2) and show under the drop name